### PR TITLE
fix: keep old iati_identifier field as deprecated

### DIFF
--- a/specifications/iati-bulk-data-service-api.yaml
+++ b/specifications/iati-bulk-data-service-api.yaml
@@ -2,7 +2,7 @@
 openapi: 3.0.4
 info:
   title: Bulk Data Service API Specification
-  version: 0.1.0
+  version: 0.1.1
 servers:
   - url: 'https://bulk-data.iatistandard.org/'
 paths:
@@ -62,6 +62,7 @@ components:
         index_created_unix_timestamp:
           type: integer
           format: int
+          example: 1751005866
           nullable: false
       required:
         - datasets
@@ -117,6 +118,16 @@ components:
           format: uuid
           example: 5401c7f4-e9fd-4ce3-b184-bfe1cb71a9f8
           nullable: false
+        iati_identifier:
+          description: |
+            This field is now deprecated in favour of `organisation_identifier`
+            which is the terminology used in the Standard for this value. This
+            field and the `organisation_identifier` field will always be
+            identical.
+          type: string
+          deprecated: true
+          example: CO-ABC-123456
+          nullable: true
         organisation_identifier:
           type: string
           example: CO-ABC-123456
@@ -182,6 +193,7 @@ components:
         index_created_unix_timestamp:
           type: integer
           format: int
+          example: 1751005866
           nullable: false
       required:
         - datasets


### PR DESCRIPTION
The previous PR (now merged) included updates to the spec for the reporting_orgs list that were agreed 2025-08-26, including the renaming of `iati_identifier` to `organisation_identifier`.  This PR adds back in `iati_identifer` as a deprecated field. This field is used by the Unified Data Pipeline Refresher, so by retaining it (for now) as a deprecated field we avoid having the sync the next release of the Bulk Data Service with a release of the Pipeline Refresher.

[Temporary link to view rendered docs](https://petstore.swagger.io/?url=https://petstore.swagger.io/?url=https://raw.githubusercontent.com/IATI/iati-unified-platform-docs/9b2a4488153ef96dd10077cf7a7d6277c48bb081/specifications/iati-bulk-data-service-api.yaml) until merged.