### PR TITLE
API and documentation changes to support tools and tool management in RYD

### DIFF
--- a/docs/developer-guide-registry-replacement.rst
+++ b/docs/developer-guide-registry-replacement.rst
@@ -207,9 +207,9 @@ To setup a *tool* in Register Your Data and add/remove *admin users* please `con
 
 There are some notable restrictions for provider admin:
 
-* A call to the ``/reporting-orgs`` endpoint in the :ref:`Register Your Data API <register-your-data-api>` will not return a list of all the reporting orgs that the user has access to via provider admin.  *Tools* should know the reporting organisation UUIDs for which their tool has access.
-* Per-tool permissions are not currently supported but may be implemented in the future.
 * An *admin user* for a *tool* cannot have an *admin*, *editor* or *contributor* role to access any reporting organisation.  In these cases users should have separate accounts: one for *admin user* work within *tools*, and one for any work that involves being an *admin*, *editor* or *contributor* of reporting orgs.
+* A call to the ``/reporting-orgs`` endpoint in the :ref:`Register Your Data API <register-your-data-api>` will not return a list of all the reporting orgs that the user has access to via provider admin.  *Tools* can call the ``/users/{uid}/roles`` endpoint which will provide broad information on the permissions a user has: superadmin status, the tools for which the specified user is an admin user, and the reporting orgs and roles the user has for them.  If the specified user is an *admin user* for a *tool* then this will only include *provider_admin* roles, otherwise, it will show regular roles.
+* Per-tool permissions are not currently supported but may be implemented in the future.
 * Eventually IATI Account will enable users to see which *tools* have been given provider admin permission, and to revoke and grant this permission.  It will not enable reporting organisation users to see the names of *admin users* of *tools*.
 * Lists of users with reporting organisation roles (*admin*, *editor* or *contributor*) will not include *tools*.
 

--- a/docs/developer-guide-registry-replacement.rst
+++ b/docs/developer-guide-registry-replacement.rst
@@ -137,6 +137,11 @@ The table below shows the fine-grained authorisations that these roles have:
      -
      -
      -
+   * - ``set-org-tool-authz``
+     - .. centered:: x
+     - .. centered:: x
+     -
+     -
    * - ``read-dataset``
      - .. centered:: x
      - .. centered:: x
@@ -172,6 +177,7 @@ Relative to an admin, an editor cannot:
 Relative to an editor, a contributor cannot:
 
 * Update an organisation's metadata.
+* Authorise a tool to access the records of this reporting organisation (or revoke that access).
 * Delete a dataset.
 
 Super-administration

--- a/docs/developer-guide-registry-replacement.rst
+++ b/docs/developer-guide-registry-replacement.rst
@@ -192,7 +192,7 @@ There are three components to the Provider Admin model:
 
 1. A *tool* is a third party software application that is developed, maintained and offered by a *provider*.  Such tools are built to work with Register Your Data.  One *provider* may offer a number of tools to suit different business and user needs.
 2. Reporting organisations can give provider admin permission for *tool(s)* to access and edit its records.
-3. A user with an IATI Account can be attached to a *tool* and they then become an *admin user* of that tool.  When logged into IATI infrastructure these *admin users* will have permissions to make changes to any reporting organisation that has given permission to that *tool*.
+3. A user with an IATI Account can be attached to a *tool* and they then become an *admin user* of that tool.  When logged into IATI infrastructure - **and when the access token is scoped to include that tool**, these *admin users* will have permissions to make changes to any reporting organisation that has given permission to that *tool*.  Normally the access token scoping will be achieved by calling RYD with an access token that has been obtained by a call to the identity service from that tool.  This means that a tool admin user cannot use provider admin permissions in a different tool.
 
 By way of example:
 
@@ -201,6 +201,7 @@ By way of example:
 * A staff member, "Analyst", at "Aid Support Company" provides support for users of "Aid Support Tool".  The IATI Secretariat add this staff member to the "Aid Support Tool" in Register Your Data.
 * When "Analyst" logs into "Aid Support Tool" they will be able to read the datasets of "Aid Agency" and update these records via Register Your Data.
 * These changes will be recorded as having being performed by "Aid Agency" (as "Aid Support Company" is providing support to "Aid Agency" under contract).
+* As "Analyst" has logged in via single-sign on, they could then log into another IATI tool, for example, IATI Account.  However, "Analyst" will not have provider admin within IATI Account and so this functionality will not be available in that tool.
 
 To setup a *tool* in Register Your Data and add/remove *admin users* please `contact us <https://iatistandard.org/en/guidance/get-support/>`_.
 

--- a/docs/specifications/iati-register-your-data-api.yaml
+++ b/docs/specifications/iati-register-your-data-api.yaml
@@ -641,6 +641,152 @@ paths:
         - Reporting Orgs
         - Datasets
       #
+      # Tool permission endpoints for provider admin
+      #
+  "/reporting-orgs/{oid}/tools":
+    get:
+      operationId: get_reporting_org_tool_list
+      summary: Get list of tools that have permission to perform changes to this
+        organisation and its datasets.
+      parameters:
+        - name: oid
+          in: path
+          description: UUID of organisation.
+          required: true
+          schema:
+            type: string
+            format: uuid
+            example: 5401c7f4-e9fd-4ce3-b184-bfe1cb71a9f8
+      responses:
+        "200":
+          description: Successfully returned tool list.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ReportingOrgToolList"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorised"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+      security:
+        - openIdConnect:
+            - "ryd"
+            - "ryd:reporting_org:tool"
+      tags:
+        - Provider admin
+        - Reporting Orgs
+    post:
+      operationId: authorise_tool_permission_for_reporting_org
+      summary: >-
+        Authorise a tool to access a reporting org's records.
+      parameters:
+        - name: oid
+          in: path
+          description: UUID of organisation.
+          required: true
+          schema:
+            type: string
+            format: uuid
+            example: 5401c7f4-e9fd-4ce3-b184-bfe1cb71a9f8
+      requestBody:
+        description: Object containing the UUID of the tool that the user wants to
+          authorise.
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                tid:
+                  type: string
+                  format: uuid
+                  example: 3144083e-6506-4126-83ed-4f5d7c9d17a8
+      responses:
+        "201":
+          description: Successfully authorised tool.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/BaseResponse"
+              example:
+                status: success
+                error: null
+                data: null
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorised"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+      security:
+        - openIdConnect:
+            - "ryd"
+            - "ryd:reporting_org:tool:update"
+      tags:
+        - Provider admin
+        - Reporting Orgs
+  "/reporting-orgs/{uid}/tools/{tid}":
+    delete:
+      operationId: revoke_tool_permission_for_reporting_org
+      summary: >-
+        Revoke the permission for a tool to access the records of a reporting
+        organisation via provider admin.
+      parameters:
+        - name: uid
+          in: path
+          description: UUID of user.
+          required: true
+          schema:
+            type: string
+            format: uuid
+            example: 6423b556-73de-4969-a2f1-91a38bca92b3
+        - name: tid
+          in: path
+          description: UUID of tool.
+          required: true
+          schema:
+            type: string
+            format: uuid
+            example: 3144083e-6506-4126-83ed-4f5d7c9d17a8
+      responses:
+        "200":
+          description: >-
+            Successfully revoked the permission for the tool.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/BaseResponse"
+              example:
+                status: success
+                error: null
+                data: null
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorised"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+      security:
+        - openIdConnect:
+            - "ryd"
+            - "ryd:reporting_org:tool:update"
+      tags:
+        - Provider admin
+        - Reporting Orgs
+      #
       # User-focused resource endpoints
       #
   "/users/{uid}/reporting-org":
@@ -1586,9 +1732,33 @@ components:
               type: array
               items:
                 $ref: "#/components/schemas/OrgAction"
-    #
-    # Reporting org response schemas
-    #
+    ReportingOrgToolList:
+      description: List of tools that have been authorised for a reporting organisation.
+      properties:
+        status:
+          type: string
+          example: success
+        error:
+          type: object
+          example: null
+        data:
+          type: array
+          items:
+            type: object
+            properties:
+              id:
+                type: string
+                format: uuid
+                example: 3144083e-6506-4126-83ed-4f5d7c9d17a8
+              name:
+                type: string
+                example: Aid Support Tool
+              provider:
+                type: string
+                example: Aid Support Company
+                  #
+                  # Reporting org response schemas
+                  #
     DiscoverableReportingOrgList:
       description: Schema for a list of discoverable reporting organisations.
       properties:
@@ -2084,6 +2254,8 @@ components:
             "ryd:reporting_org:delete": Delete an organisation.
             "ryd:reporting_org:user": List the users associated with an organisation.
             "ryd:reporting_org:user:update": Update the users associated with an organisation.
+            "ryd:reporting_org:tool": List the tools that have permissions to access to organisation.
+            "ryd:reporting_org:tool:update": Update the tools that have permissions to access to organisation.
             "ryd:dataset": Create and read.
             "ryd:dataset:update": Update dataset metadata and URLs.
             "ryd:dataset:delete": Delete datasets.

--- a/docs/specifications/iati-register-your-data-api.yaml
+++ b/docs/specifications/iati-register-your-data-api.yaml
@@ -811,6 +811,41 @@ paths:
             - "ryd:reporting_org:user:update"
       tags:
         - Users
+  "/users/{uid}/roles":
+    get:
+      operationId: get_user_roles
+      summary: Get a list of the roles a user has.
+      parameters:
+        - name: uid
+          in: path
+          description: UUID of user.
+          required: true
+          schema:
+            type: string
+            format: uuid
+            example: 6423b556-73de-4969-a2f1-91a38bca92b3
+      responses:
+        "200":
+          description: Successfully returned roles list.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UserRoles"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorised"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+      security:
+        - openIdConnect:
+            - "ryd"
+      tags:
+        - Users
       #
       # Dataset-focused resource endpoints
       #
@@ -1531,6 +1566,46 @@ components:
                   - editor
                   - contributor
                   - contributor_pending
+    UserRoles:
+      description: List of roles that a user has.
+      properties:
+        status:
+          type: string
+          example: success
+        error:
+          type: object
+          example: null
+        data:
+          type: object
+          properties:
+            superadmin:
+              type: boolean
+              example: false
+            tools:
+              type: array
+              items:
+                type: string
+                format: uuid
+                example: 3144083e-6506-4126-83ed-4f5d7c9d17a8
+            reporting_orgs:
+              type: array
+              items:
+                type: object
+                properties:
+                  id:
+                    type: string
+                    format: uuid
+                    example: 5401c7f4-e9fd-4ce3-b184-bfe1cb71a9f8
+                  role:
+                    type: string
+                    example: provider_admin
+                    enum:
+                      - admin
+                      - editor
+                      - contributor
+                      - contributor_pending
+                      - provider_admin
+
     #
     # Dataset schemas
     #

--- a/docs/specifications/iati-register-your-data-api.yaml
+++ b/docs/specifications/iati-register-your-data-api.yaml
@@ -1107,6 +1107,42 @@ paths:
             - "ryd:dataset:delete"
       tags:
         - Datasets
+  #
+  # Tool list endpoint
+  #
+  /tools:
+    get:
+      operationId: get_tool_list
+      summary: Get a list of third party tools that can work with Register Your Data.
+      description: >-
+        This endpoint is provided to help clients provide lists of third party
+        tools that are used for provider admin functionality.  The intention
+        behind this endpoint is to show tool metadata to end users.
+      responses:
+        "200":
+          description: Successfully fetched list of tools.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ToolList"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorised"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+      security:
+        - clientCredentials:
+            - "ryd"
+        - openIdConnect:
+            - "ryd"
+      tags:
+        - Provider admin
+  #
+  # Miscellaneous endpoints
+  #
   /licences:
     get:
       operationId: get_licences
@@ -1812,6 +1848,34 @@ components:
               - legacy
               - supported
               - preferred
+    #
+    # Tool schemas
+    #
+    ToolList:
+      description: "List of tools, their names and providers."
+      type: object
+      properties:
+        status:
+          type: string
+          example: success
+        error:
+          type: object
+          example: null
+        data:
+          type: array
+          items:
+            type: object
+            properties:
+              id:
+                type: string
+                format: uuid
+                example: 3144083e-6506-4126-83ed-4f5d7c9d17a8
+              name:
+                type: string
+                example: Aid Support Tool
+              provider:
+                type: string
+                example: Aid Support Company
   # ===============================================================
   #
   # All responses

--- a/docs/specifications/iati-register-your-data-api.yaml
+++ b/docs/specifications/iati-register-your-data-api.yaml
@@ -54,7 +54,7 @@ info:
   license:
     name: GNU Affero General Public Licence 3.0
     url: "https://www.gnu.org/licenses/agpl-3.0.en.html"
-  version: 0.9.14
+  version: 0.9.15
 servers:
   - url: "https://dev.api.registeryourdata.iatistandard.org/api/v1"
   - url: "https://api.registeryourdata.iatistandard.org/api/v1"

--- a/docs/specifications/iati-register-your-data-api.yaml
+++ b/docs/specifications/iati-register-your-data-api.yaml
@@ -57,6 +57,7 @@ info:
   version: 0.9.14
 servers:
   - url: "https://dev.api.registeryourdata.iatistandard.org/api/v1"
+  - url: "https://api.registeryourdata.iatistandard.org/api/v1"
 # ===============================================================
 #
 # Endpoints

--- a/docs/specifications/iati-register-your-data-api.yaml
+++ b/docs/specifications/iati-register-your-data-api.yaml
@@ -846,6 +846,50 @@ paths:
             - "ryd"
       tags:
         - Users
+  "/users/{uid}/roles/reporting-org-permissions/{oid}":
+    get:
+      operationId: get_user_fga_for_reporting_org
+      summary: Get a list of the fine grained authorisations a user has for a given
+        reporting org.
+      parameters:
+        - name: uid
+          in: path
+          description: UUID of user.
+          required: true
+          schema:
+            type: string
+            format: uuid
+            example: 6423b556-73de-4969-a2f1-91a38bca92b3
+        - name: oid
+          in: path
+          description: UUID of organisation.
+          required: true
+          schema:
+            type: string
+            format: uuid
+            example: 5401c7f4-e9fd-4ce3-b184-bfe1cb71a9f8
+      responses:
+        "200":
+          description: Successfully returned fine-grained authorisations list.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UserFineGrainedAuthorisationsForReportingOrg"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorised"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+      security:
+        - openIdConnect:
+            - "ryd"
+      tags:
+        - Users
       #
       # Dataset-focused resource endpoints
       #
@@ -1605,6 +1649,31 @@ components:
                       - contributor
                       - contributor_pending
                       - provider_admin
+    UserFineGrainedAuthorisationsForReportingOrg:
+      description: List of fine-grained authorisations that a user has for a reporting org.
+      properties:
+        status:
+          type: string
+          example: success
+        error:
+          type: object
+          example: null
+        data:
+          type: array
+          items:
+            type: string
+            example: read-org
+            enum:
+              - read-org
+              - update-org
+              - delete-org
+              - set-org-user-authz
+              - set-org-tool-authz
+              - read-dataset
+              - create-dataset
+              - update-dataset
+              - update-dataset-visibility
+              - delete-dataset
 
     #
     # Dataset schemas


### PR DESCRIPTION
This PR makes three substantive changes:

1. It adds a number of endpoints to support tools in discovering permissions and roles that the user has, and obtaining information about tools that have provider admin access to RYD.
2. It adds a number of tool management endpoints to allow users to give or revoke provider admin permissions.
3. It updates the developer guide to a) add an additional fine-grained authorisation to support management of tools; b) a description of the endpoints for permission discovery; c) highlight that provider admin users will only have provider admin functionality within the tool that is authorised for that functionality.
