### PR TITLE
Update developer guide docs on contributor permissions

### DIFF
--- a/docs/developer-guide-registry-replacement.rst
+++ b/docs/developer-guide-registry-replacement.rst
@@ -155,7 +155,7 @@ The table below shows the fine-grained authorisations that these roles have:
    * - ``update-dataset``
      - .. centered:: x
      - .. centered:: x
-     -
+     - .. centered:: x
      - .. centered:: x
    * - ``update-dataset-visibility``
      - .. centered:: x


### PR DESCRIPTION
This updates the docs to match the permissions contributors were listed as having in the old docs and the permissions they do have in the RYD API.