### PR TITLE
fix(dev guide): update editor permissions

### DIFF
--- a/docs/developer-guide-registry-replacement.rst
+++ b/docs/developer-guide-registry-replacement.rst
@@ -159,7 +159,7 @@ The table below shows the fine-grained authorisations that these roles have:
      - .. centered:: x
    * - ``update-dataset-visibility``
      - .. centered:: x
-     -
+     - .. centered:: x
      -
      - .. centered:: x
    * - ``delete-dataset``


### PR DESCRIPTION
This updates the docs to match the permissions editors should have, matching current RYD API behaviour.