### PR TITLE
feat: adopt template conf.py and wire plausible_domain

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -14,7 +14,27 @@ from sphinx.locale import get_translation
 import iati_sphinx_theme
 
 # Import project-specific settings
-from project_info import project, eyebrow_text, github_repository, languages, redoc
+from project_info import (
+    project,
+    tool_url,
+    nav_label,
+    eyebrow_text,
+    github_repository,
+    languages,
+    plausible_domain,
+    redoc,
+)
+
+# Derive nav and title from project_info. When tool_url is set, the
+# header shows two nav items: the tool itself, and a self-link to the
+# documentation. When unset, just the self-link.
+_nav_label = nav_label or project
+if tool_url:
+    tool_nav_items = {_nav_label: tool_url}
+    project_title = f"{_nav_label}: Documentation"
+else:
+    tool_nav_items = {}
+    project_title = project
 
 MESSAGE_CATALOG_NAME = "iati-sphinx-theme"
 _ = get_translation(MESSAGE_CATALOG_NAME)
@@ -49,8 +69,10 @@ html_theme_options = {  # See https://iati-sphinx-theme.readthedocs-hosted.com/e
     "header_title_text": _(project),
     "header_eyebrow_text": _(eyebrow_text),
     "languages": languages,
-    "project_title": _(project),
+    "plausible_domain": plausible_domain,
+    "project_title": _(project_title),
     "show_download_links": True,
+    "tool_nav_items": tool_nav_items,
 }
 
 # Add any paths that contain custom static files (such as style sheets, videos,

--- a/docs/project_info.py
+++ b/docs/project_info.py
@@ -2,14 +2,27 @@
 # This file contains settings that vary per repository.
 # The main conf.py imports these values and can be synced across all repos.
 
+from urllib.parse import urlparse
+
 # Project name (used for titles, headers, and Sphinx internals)
 project = "IATI Unified Platform"
+
+# URL of the live tool this repo documents. None when the docs themselves
+# are the deliverable (no separate tool to link).
+tool_url = None
+
+# Short label used in the nav. Defaults to ``project`` when None.
+nav_label = None
 
 # Eyebrow text (small label above the page title)
 eyebrow_text = "IATI Tools: Documentation"
 
 # GitHub repository URL (for "Edit on GitHub" links)
 github_repository = "https://github.com/IATI/iati-unified-platform-docs"
+
+# Plausible analytics domain, derived from tool_url so docs are tracked
+# under the tool's site. Set to None to disable.
+plausible_domain = urlparse(tool_url).hostname if tool_url else None
 
 # Supported languages for the documentation
 languages = ["en"]


### PR DESCRIPTION
Finish the interrupted conf.py migration: add plausible_domain (derived from tool_url) to project_info.py and adopt the template conf.py verbatim, so conf.py becomes syncable. Turns on Plausible for repos that set a tool_url.